### PR TITLE
add workaround for buggy clients

### DIFF
--- a/rest/index.php
+++ b/rest/index.php
@@ -136,6 +136,21 @@ foreach ($query as $param) {
     list($name, $value) = explode('=', $param);
     $decname            = urldecode($name);
     $decvalue           = urldecode($value);
+    
+    // workaround for clementine/Qt5 bug
+    // see https://github.com/clementine-player/Clementine/issues/6080
+    $matches = array();
+    if($decname == "id" && preg_match('/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/', $decvalue, $matches)) {
+        $calc = (($matches[1] << 24) + ($matches[2] << 16) + ($matches[3] << 8) + $matches[4]);
+        if($calc) {
+            debug_event('subsonic', "Got id parameter $decvalue, which looks like an IP address. This is a known bug in some players, rewriting it to $calc", '4');
+            $decvalue = $calc;
+        }
+        else {
+            debug_event('subsonic', "Got id parameter $decvalue, which looks like an IP address. Recalculation of the correct id failed, though", '4');
+        }
+    }
+
     if (array_key_exists($decname, $params)) {
         if (!is_array($params[$decname])) {
             $oldvalue           = $params[$decname];


### PR DESCRIPTION
Some buggy (supposedly QT5) clients send the id parameter formatted as an IP address (sic!) to the Subsonic API.
See https://github.com/clementine-player/Clementine/issues/6080 and https://github.com/ampache/ampache/issues/1704
This workaround tries to detect that and calculate the correct song id from the parameter before passing it on.